### PR TITLE
Add a "fading in background image" on homepage.

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -9,7 +9,7 @@ const PageHeader = styled.header`
   -webkit-transition: background-color 0.2s ease;
   -ms-transition: background-color 0.2s ease;
   transition: background-color 0.2s ease;
-  background: #2e3842;
+  background: transparent;
   height: 3em;
   left: 0;
   line-height: 3em;

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -5,7 +5,10 @@ import { withScroll } from 'react-window-decorators'
 import transition from 'styled-transition-group'
 
 const LogoWrap = transition.div`
+  background: rgb(46, 56, 66);
+  height: 100%;
   opacity: 1;
+  width: 100%;
   
   &:enter {
     opacity: 0;

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -10,6 +10,7 @@ import Practices from '../components/Practices'
 import CallToAction from '../components/CallToAction'
 import Button from '../components/Button'
 import arrow from '../img/arrow.svg'
+import bgimage from '../img/banner.jpg'
 
 const Intro = styled.section`
   display: -moz-flex;
@@ -28,16 +29,44 @@ const Intro = styled.section`
   overflow: hidden;
   position: relative;
   text-align: center;
-  
   padding: 7em 3em 7em 3em;
-    height: auto;
-    min-height: 0;
+  height: auto;
+  min-height: 0;
   
   ${media.greaterThan('737px')`
     height: 100vh;
     min-height: 35em;
     padding: 0;
   `}
+  
+`
+const IntroBackground = transition.div`
+  
+    background-image: -moz-linear-gradient(top, rgba(0,0,0,0.5), rgba(0,0,0,0.5)),url(${props => props['data-bgimage']});
+    background-image: -webkit-linear-gradient(top, rgba(0,0,0,0.5), rgba(0,0,0,0.5)),url(${props => props['data-bgimage']});
+    background-image: -ms-linear-gradient(top, rgba(0,0,0,0.5), rgba(0,0,0,0.5)),url(${props => props['data-bgimage']});
+    background-image: linear-gradient(top, rgba(0,0,0,0.5), rgba(0,0,0,0.5)),url(${props => props['data-bgimage']});
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    content: "";
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    opacity: 1;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    z-index: -1;
+    
+    &:enter {
+      opacity: 0;
+    }
+    &:enter-active {
+      opacity: 1;
+      transition: opacity 3.5s ease;
+    }
   
 `
 const IntroHeadline = transition.h1`
@@ -201,6 +230,7 @@ class HomePageTemplate extends React.Component {
           <meta name='description' content={this.props.meta_description} />
         </Helmet>
         <Intro innerRef={(elem) => { this.intro = elem }}>
+          <IntroBackground data-bgimage={bgimage} mountOnEnter unmountOnExit timeout={3500} in={this.state.startSecondAnimation} />
           <div>
             <IntroHeadline
               unmountOnExit


### PR DESCRIPTION
I added a background div which holds the background image. This then gets faded in on page load. The header's background on the homepage now also gets faded in only after the page was scrolled (otherwise it would overlap the background image). Fixes #35.